### PR TITLE
docs: READMEの統計画像にキャッシュバスター用クエリを更新（v14, 2025/10/12 11:29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ CakePHP / MariaDB を中心に勉強・開発中です。
 
 <!-- ▼GitHub Readme Stats : 総合ステータスカード
      Publicリポジトリのみを対象に、年間コミット数・スター数・フォーク数などを表示します -->
-![GitHub Stats](https://github-readme-stats.vercel.app/api?username=aaruupaka&show_icons=true&v=13)
+![GitHub Stats](https://github-readme-stats.vercel.app/api?username=aaruupaka&show_icons=true&v=14)
 
 <!-- ▼Top Languages : 言語構成比
      公開リポジトリ内のコード量を言語別に集計して表示します
      → ファイルの拡張子を元に集計（行数ベース） -->
-![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=aaruupaka&layout=compact&v=13)
+![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=aaruupaka&layout=compact&v=14)
 
 <!-- ▼GitHub Streak Stats : 連続コミット日数
      連続してコミットした日数（現在のstreakと最長streak）を表示します -->
-![GitHub Streak](https://streak-stats.demolab.com?user=aaruupaka&v=13)
+![GitHub Streak](https://streak-stats.demolab.com?user=aaruupaka&v=14)
 
 <!-- ▼GitHub Profile Trophy : 貢献実績トロフィー
      フォロワー数・スター数・コミット数などをトロフィー風に可視化します -->
-![trophy](https://github-profile-trophy.vercel.app/?username=aaruupaka&theme=gruvbox&v=13)
+![trophy](https://github-profile-trophy.vercel.app/?username=aaruupaka&theme=gruvbox&v=14)
 
 ---
 


### PR DESCRIPTION
# 目的
- READMEの統計画像を最新の状態に更新する

# 作業内容
- キャッシュバスターのクエリをv=13からv=14に更新